### PR TITLE
ie7-8 fix

### DIFF
--- a/PxLoader.js
+++ b/PxLoader.js
@@ -114,6 +114,7 @@ function PxLoader(settings) {
             // now check priority
             if (a.priority < b.priority) return -1;
             if (a.priority > b.priority) return 1;
+            return 0;
         }
     };
 


### PR DESCRIPTION
IE8 errors with "Number expected" in array.sort if you don't return 0 when the elements are equal.
