### PR TITLE
status should be used when we create the entry

### DIFF
--- a/PxLoader.js
+++ b/PxLoader.js
@@ -65,7 +65,7 @@ function PxLoader(settings) {
 
         entries.push({
             resource: resource,
-            state: ResourceState.QUEUED
+            status: ResourceState.QUEUED
         });
     };
 


### PR DESCRIPTION
There is an error when we create the entry and we push it into the array of entries.. We set the resource and the state, but the state is never used in the code. It should be "status".
