### PR TITLE
Fix `PxLoaderTags#contains` always returning true when comparing tag arrays with only one element

### DIFF
--- a/PxLoader.js
+++ b/PxLoader.js
@@ -349,7 +349,7 @@ function PxLoaderTags(values) {
     this.contains = function(other) {
         if (this.length === 0 || other.length === 0) {
             return false;
-        } else if (this.length === 1) {
+        } else if (this.length === 1 && this.value !== null) {
             if (other.length === 1) {
                 return this.value === other.value;
             } else {


### PR DESCRIPTION
The problem is:

```
new PxLoaderTags('tag').contains(new PxLoaderTags('tag2')) ==> false
new PxLoaderTags(['tag1']).contains(new PxLoaderTags(['tag2'])) ==> true
```

This happens because `contains` checks if the length of both arrays is one and
if this is the case it tries to compare the supposed singular value from both.
This then results in comparing null against null and then returning true, incorrectly.
