### PR TITLE
ability to only load ressources with specified tags

### DIFF
--- a/PxLoader.js
+++ b/PxLoader.js
@@ -130,18 +130,27 @@
             };
         };
 
-        this.start = function(orderedTags) {
+        this.start = function(orderedTags, specifiedTagsOnly) {
             timeStarted = Date.now();
 
             // first order the resources
-            var compareResources = getResourceSort(orderedTags);
+            var compareResources = getResourceSort(orderedTags),
+                tags = new PxLoaderTags(orderedTags),
+                i = 0, 
+                len = entries.length,
+                entry;
+
             entries.sort(compareResources);
 
             // trigger requests for each resource
-            for (var i = 0, len = entries.length; i < len; i++) {
-                var entry = entries[i];
-                entry.status = ResourceState.WAITING;
-                entry.resource.start(this);
+            for (; i < len; i++) {
+
+                entry = entries[i];
+                //when specifiedTagsOnly: only start resource if it has given tags
+                if( !specifiedTagsOnly || (specifiedTagsOnly && tags.intersects(entry.resource.tags)) ) {
+                    entry.status = ResourceState.WAITING;
+                    entry.resource.start(this);
+                }
             }
 
             // do an initial status check soon since items may be loaded from the cache


### PR DESCRIPTION
Hey.
I added the following functionality:

It is now possible to load ressources in groups, defined by tags. Each group can have an own completionListener. 
An example: you want to load a group of ressources on document ready. Later, when the user performs a specific action, you want to preload other ressources and treat them differently when loading is complete.

All you have to do is pass `true` as a second argument to the start-function  (`specifiedTagsOnly`).

A quick demo: http://jsbin.com/ugojeb/2/

``` javascript
loader.addImage( 'http://placekitten.com/200/300', 'initial' );
loader.addImage( 'http://placekitten.com/200/300', 'content' );

loader.addCompletionListener(function() {
    [...]
}, 'initial');
loader.addCompletionListener(function() {
    [...]
}, 'content');

loader.start('initial', true);
$('button').on('click', function() {
  loader.start('content', true);
});
```
