### PR TITLE
Fixed a typo to correct uglify task call

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
         watch: {
             cj: {
                 files: ['<%= jshint.files %>'],
-                tasks: ['jshint', 'concat', 'uglfiy']
+                tasks: ['jshint', 'concat', 'uglify']
             }
         },
         uglify: {


### PR DESCRIPTION
Literally just swapped two letters :)

Location: grunt.initConfig(watch.cj.tasks['uglify'])
