### PR TITLE
Correct error "this.img is undefined"

### DIFF
--- a/PxLoaderVideo.js
+++ b/PxLoaderVideo.js
@@ -14,7 +14,7 @@ function PxLoaderVideo(url, tags, priority, origin) {
     }
 
     if(origin !== undefined) {
-        this.img.crossOrigin = origin;
+        this.vid.crossOrigin = origin;
     }
     this.tags = tags;
     this.priority = priority;


### PR DESCRIPTION
PxLoaderVideo.js was referencing an img undefined attribute.

It closes Issue #36.